### PR TITLE
Fix remote_port(), send()

### DIFF
--- a/wiznet5k.py
+++ b/wiznet5k.py
@@ -336,7 +336,7 @@ class WIZNET5K:  # pylint: disable=too-many-public-methods
             return self._pbuff
         for octet in range(0, 2):
             self._pbuff[octet] = self._read_socket(socket_num, REG_SNDPORT + octet)[0]
-        return int((self._pbuff[0] << 8) | self._pbuff[0])
+        return int((self._pbuff[0] << 8) | self._pbuff[1])
 
     @property
     def ifconfig(self):

--- a/wiznet5k_socket.py
+++ b/wiznet5k_socket.py
@@ -256,8 +256,9 @@ class socket:
         a remote socket.
         :param bytearray data: Desired data to send to the socket.
         """
-        _the_interface.socket_write(self.socknum, data, self._timeout)
+        ret = _the_interface.socket_write(self.socknum, data, self._timeout)
         gc.collect()
+        return ret
 
     def sendto(self, data, address):
         """Send data to the socket. The socket must be connected to


### PR DESCRIPTION
Bug in `remote_port()` was returning incorrect port number; socket.send() wasn't returning anything (should return number of bytes sent)